### PR TITLE
(fix): Prevent dependabot from running integration tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,6 +17,7 @@ jobs:
           npm run all
   test:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: write
       actions: write

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,7 +15,8 @@ jobs:
           npm install
       - run: |
           npm run all
-  test:
+  
+  integration-test:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:


### PR DESCRIPTION
Integrations tests involve dispatching numerous GitHub Workflows, which could be potentially spammed by multiple `dependabot` Pull Requests. We still allow `dependabot` to run unit tests as this is a single job with no calls to the GitHub API